### PR TITLE
fix(justfile): render readable just --list descriptions

### DIFF
--- a/examples/reference-service/justfile
+++ b/examples/reference-service/justfile
@@ -26,22 +26,26 @@ test:
 imports:
     uv run lint-imports
 
-# `git ls-files` scopes this to the project's own files. `--all-files` walks
-# up to the enclosing repository when this project sits inside one, and
-# rewrites files outside it — during development that silently reformatted
-# Python snippets inside this plan's own Markdown. In a standalone generated
-# project the two are equivalent, so this is correct in both layouts.
+# Run the pre-commit hooks over this project's own files.
 precommit:
+    # `git ls-files` scopes this to the project's own files. `--all-files`
+    # walks up to the enclosing repository when this project sits inside
+    # one, and rewrites files outside it — during development that silently
+    # reformatted Python snippets inside this plan's own Markdown. In a
+    # standalone generated project the two are equivalent, so this is
+    # correct in both layouts.
     uv run pre-commit run --files $(git ls-files)
 
-# Several pre-commit hooks mutate files (ruff-format, uv-lock,
-# end-of-file-fixer, trailing-whitespace), so `precommit` above can modify
-# the tree and still exit 0 — a `check` that only runs it would pass on a
-# second run without anyone noticing the tree changed. `git diff --exit-code`
-# after it turns any such mutation into a loud failure instead of a silent
-# one. Keep the hooks running here regardless: that is how we know the
-# config itself still works, not just that the tree was already clean.
+# Everything CI checks, failing loudly if a hook modified the tree.
 check: lint typecheck imports test precommit
+    # Several pre-commit hooks mutate files (ruff-format, uv-lock,
+    # end-of-file-fixer, trailing-whitespace), so `precommit` above can
+    # modify the tree and still exit 0 — a `check` that only runs it would
+    # pass on a second run without anyone noticing the tree changed.
+    # `git diff --exit-code` after it turns any such mutation into a loud
+    # failure instead of a silent one. Keep the hooks running here
+    # regardless: that is how we know the config itself still works, not
+    # just that the tree was already clean.
     git diff --exit-code
 
 up:


### PR DESCRIPTION
## What changed

`examples/reference-service/justfile`: the `check` and `precommit` recipes each had a multi-line rationale comment block sitting directly above them. `just` uses only the **last line** of such a block as the recipe description, so `just --list` rendered two meaningless mid-sentence fragments:

```
check     # config itself still works, not just that the tree was already clean.
precommit # project the two are equivalent, so this is correct in both layouts.
```

Now it renders:

```
check     # Everything CI checks, failing loudly if a hook modified the tree.
precommit # Run the pre-commit hooks over this project's own files.
```

## How

The full rationale moved into each recipe body as indented comments, which `just --list` ignores, leaving a single one-line summary above each recipe. This is the pattern already used by the `docs-build` recipe.

The rationale text is preserved **word for word** — only the line wrapping changed, to fit the four-space indent. No recipe behavior changed; only comments moved.

## Verification

`just --justfile examples/reference-service/justfile --list` renders both descriptions as complete sentences.

`just check` passes end to end in `examples/reference-service`:

| Stage | Result |
| --- | --- |
| `ruff check` | All checks passed |
| `ruff format --check` | 43 files already formatted |
| `mypy` | no issues in 42 source files |
| `lint-imports` | 2 contracts kept, 0 broken |
| `pytest` | 102 passed in 3.54s |
| `pre-commit` | 8 passed, 1 skipped (`uv-lock`, no files to check) |
| `git diff --exit-code` | no output — no hook mutated the tree |

## For the reviewer

One trade-off worth knowing: `just` echoes every recipe body line before executing it, so `just check` now prints those eight rationale lines to the terminal during a run. `just --list` ignores them, which was the goal, and the existing `docs-build` recipe behaves the same way — so I kept it consistent rather than diverging. Prefixing each comment line with `@` would suppress the echo if that noise turns out to be unwelcome; happy to change it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
